### PR TITLE
enabling multiple levels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./project"
+    ]
+}

--- a/project/__main__.py
+++ b/project/__main__.py
@@ -16,55 +16,6 @@ def main():
     It then initializes these componenets and separates them into groups and sub groups. I then passes it to
     the start view object.
     """
-    
-#########################Scene Objects######################################  
-
-    # Initializes arcade Scene object
-    scene = arcade.Scene()
-
-    # Layer Specific Options for the Tilemap
-    layer_options = {
-        constants.LAYER_NAME_PLATFORMS: {
-            "use_spatial_hash": True,
-        },
-        constants.LAYER_NAME_FOREGROUND: {
-            "use_spatial_hash": True,
-            },
-        constants.LAYER_NAME_LADDERS: {
-            "use_spatial_hash": True,
-            },
-        constants.LAYER_NAME_COINS: {
-            "use_spatial_hash": True,
-            },
-        constants.LAYER_NAME_PLAYER: {
-            "use_spatial_hash": False,
-            },
-        constants.LAYER_NAME_TRAPS: {
-            "use_spatial_hash": True,
-            },        
-        constants.LAYER_NAME_CRYSTALS: {
-            "use_spatial_hash": True,
-            },
-        constants.LAYER_NAME_BACKGROUND: {
-            "use_spatial_hash": True,
-            },
-        constants.LAYER_NAME_RIDDLEMASTER: {
-            "use_spatial_hash": True,
-            },
-    }
-
-    # Saves the tilemap and stores in the Scene object
-    tile_map = arcade.load_tilemap(constants.MAP_NAME, constants.TILE_SCALE, layer_options)
-    scene = arcade.Scene.from_tilemap(tile_map)
-
-    # Initializes the player sprite and assigns attributes to it. Then stores it in the scene object
-    player_sprite = PlayerSpriteAnimation()
-    player_sprite.center_x = constants.START_LOCATION_X
-    player_sprite.center_y = constants.START_LOCATION_Y
-    
-    scene.add_sprite(constants.LAYER_NAME_PLAYER, player_sprite)
-
-
 #########################Cast Objects######################################
 
     # Initializing cast dictionary
@@ -90,6 +41,29 @@ def main():
     level = Actor()
     level.set_text(constants.LEVEL)
     cast["level"] = level
+
+
+
+#########################Scene Objects######################################  
+
+    # Initializes arcade Scene object
+    scene = arcade.Scene()
+
+    map_level = level.get_text()
+    map_name = f"project/game/assets/map_{map_level}.json"
+
+    # Saves the tilemap and stores in the Scene object
+    tile_map = arcade.load_tilemap(map_name, constants.TILE_SCALE, constants.LAYER_OPTIONS)
+    scene = arcade.Scene.from_tilemap(tile_map)
+
+    # Initializes the player sprite and assigns attributes to it. Then stores it in the scene object
+    player_sprite = PlayerSpriteAnimation()
+    player_sprite.center_x = constants.START_LOCATION_X
+    player_sprite.center_y = constants.START_LOCATION_Y
+    
+    scene.add_sprite(constants.LAYER_NAME_PLAYER, player_sprite)
+
+
 
 
 #########################Script Objects######################################  

--- a/project/game/constants.py
+++ b/project/game/constants.py
@@ -21,7 +21,6 @@ RIDDLEMASTER_SOUND = ":resources:sounds/upgrade3.wav"
 MAIN_FILE = ":resources:images/animated_characters/female_adventurer/femaleAdventurer"
 
 LEVEL = 1
-MAP_NAME = f"project/game/assets/map_{LEVEL}.json"
 
 RIGHT_FACING = 0
 LEFT_FACING = 1
@@ -35,6 +34,39 @@ LAYER_NAME_PLAYER = "Player"
 LAYER_NAME_CRYSTALS = "Crystals"
 LAYER_NAME_TRAPS = "Traps"
 LAYER_NAME_RIDDLEMASTER = "Riddlemaster"
+
+# Layer Specific Options for the Tilemap
+LAYER_OPTIONS = {
+    LAYER_NAME_PLATFORMS: {
+            "use_spatial_hash": True,
+        },
+    LAYER_NAME_LADDERS: {
+            "use_spatial_hash": True,
+            },
+    LAYER_NAME_COINS: {
+            "use_spatial_hash": True,
+            },
+    LAYER_NAME_PLAYER: {
+            "use_spatial_hash": False,
+            },
+    LAYER_NAME_TRAPS: {
+            "use_spatial_hash": True,
+            },        
+    LAYER_NAME_CRYSTALS: {
+            "use_spatial_hash": True,
+            },
+    LAYER_NAME_BACKGROUND: {
+            "use_spatial_hash": True,
+            },
+    LAYER_NAME_RIDDLEMASTER: {
+            "use_spatial_hash": True,
+            },
+    LAYER_NAME_FOREGROUND: {
+            "use_spatial_hash": True,
+            },
+    }
+
+
 
 RIDDLE_MASTER_SCRIPT = [[{"You've made it to the Riddle Master, click OK": ""}, 
 {"Try to make it through my Riddles by typing the correct answer, click OK": ""},

--- a/project/game/game_view.py
+++ b/project/game/game_view.py
@@ -46,6 +46,7 @@ class GameView(arcade.View):
         self.physics_engine = props["physics_engine"]
         self.gui_camera = props["gui_camera"]
         self.end_of_map = 0
+        self.level = 1
 
         # Track the current state of what key/keys is pressed
         self.left_pressed = False

--- a/project/game/handle_riddlemaster_collision_action.py
+++ b/project/game/handle_riddlemaster_collision_action.py
@@ -25,8 +25,8 @@ class HandleRiddlemasterCollisionAction(Action):
         riddlemaster_sound = arcade.load_sound(constants.RIDDLEMASTER_SOUND)
         crystal_count = cast["crystals"].get_text()
 
-        if crystal_count == 5:
-            if arcade.check_for_collision_with_list(scene["Player"][0], scene["Riddlemaster"]):
+        #if crystal_count == 5:
+        if arcade.check_for_collision_with_list(scene["Player"][0], scene["Riddlemaster"]):
 
                 arcade.play_sound(riddlemaster_sound)
                 script["view"].execute(scene, cast, props, script, "riddle")

--- a/project/game/handle_riddlemaster_collision_action.py
+++ b/project/game/handle_riddlemaster_collision_action.py
@@ -25,8 +25,8 @@ class HandleRiddlemasterCollisionAction(Action):
         riddlemaster_sound = arcade.load_sound(constants.RIDDLEMASTER_SOUND)
         crystal_count = cast["crystals"].get_text()
 
-        #if crystal_count == 5:
-        if arcade.check_for_collision_with_list(scene["Player"][0], scene["Riddlemaster"]):
+        if crystal_count == 5:
+            if arcade.check_for_collision_with_list(scene["Player"][0], scene["Riddlemaster"]):
 
                 arcade.play_sound(riddlemaster_sound)
                 script["view"].execute(scene, cast, props, script, "riddle")

--- a/project/game/level_advance_view.py
+++ b/project/game/level_advance_view.py
@@ -2,7 +2,7 @@ import arcade
 from game import constants
 from game.player_sprite_animation import PlayerSpriteAnimation
 
-class VictoryView(arcade.View):
+class LevelAdvanceView(arcade.View):
     """Creates our victory view and sets up the elements on screen. 
 
     Stereotype:
@@ -15,7 +15,7 @@ class VictoryView(arcade.View):
         script (dict): The game actions {key: tag, value: list}.
     """
 
-    def __init__(self, cast, props, script):
+    def __init__(self, scene, cast, props, script):
         """The class constructor
         Args:
             self (VictoryView): An instance of VictoryView.
@@ -26,12 +26,12 @@ class VictoryView(arcade.View):
         """
 
         super().__init__()
-        self.scene = None
+        self.scene = scene
         self.cast = cast
         self.props = props
         self.script = script
-        self.map_name = None
-        self._set_map_name(cast["level"])
+        self.map_level = cast["level"]
+        self._level_advance()
         self._new_scene()
         self._new_props()
 
@@ -53,7 +53,7 @@ class VictoryView(arcade.View):
         arcade.start_render()
         arcade.draw_text("Congratulations", self.window.width / 2, self.window.height / 2,
                         arcade.color.WHITE, font_size=50, anchor_x="center")
-        arcade.draw_text("CLICK IF YOU DARE PLAY AGAIN!", self.window.width / 2, self.window.height / 2-75,
+        arcade.draw_text("When ready CLICK to start!", self.window.width / 2, self.window.height / 2-75,
                         arcade.color.SEA_GREEN, font_size=20, anchor_x="center")
 
     def on_mouse_press(self, _x, _y, _button, _modifiers):
@@ -68,33 +68,40 @@ class VictoryView(arcade.View):
             _modifiers (??): Any effects effecting the clicking of the mouse.
         """
 
-        self.cast['lives'].set_text(constants.MAX_LIVES)
-        self.cast['score'].set_text(0)
+        self.cast['lives'].set_text(self.cast['lives'].get_text())
+        self.cast['score'].set_text(self.cast['score'].get_text())
         self.cast['crystals'].set_text(0)
-        self.cast['level'].set_text(constants.LEVEL)
+        self.cast['level'].set_text(self.map_level)
         self.script["view"].execute(self.scene, self.cast, self.props, self.script, "game")
 
-
-    def _set_map_name(self, level):
-
-        self.map_level = level.get_text()
-        self.map_name = f"project/game/assets/map_{self.map_level}.json"
-
-
-    def _new_scene(self):
-        """Private function that recreates the first level for game restart.
+    def _level_advance(self):
+        """Handles advancing and calling the number for the current level of play
         
         Args:
-            self (VictoryView): An instance of VictoryView.
+            self(level advance View): An instance of LevelAdvanceView
+
+        """
+        #adds one to the current level
+        self.map_level.add_number()
+
+        #set the level variable from the level object
+        self.map_level = self.map_level.get_text()
+        
+    def _new_scene(self):
+        """Private function that recreates the first level for next game level.
+        
+        Args:
+            self (Level advance view): An instance of LevelAdvanceView.
         """
 
         # Initializes arcade Scene object
         self.scene = arcade.Scene()
 
 
+        map_name = f"project/game/assets/map_{self.map_level}.json"
 
         # Saves the tilemap and stores in the Scene object
-        tile_map = arcade.load_tilemap(self.map_name, constants.TILE_SCALE, constants.LAYER_OPTIONS)
+        tile_map = arcade.load_tilemap(map_name, constants.TILE_SCALE, constants.LAYER_OPTIONS)
         self.scene = arcade.Scene.from_tilemap(tile_map)
 
 

--- a/project/game/riddlemaster_view.py
+++ b/project/game/riddlemaster_view.py
@@ -124,7 +124,7 @@ class RiddlemasterView(arcade.View):
                 self.script["view"].execute(self.scene, self.cast, self.props, self.script, "game_over")
         else:
             self.iter = 0
-            self.script["view"].execute(self.scene, self.cast, self.props, self.script, "victory")
+            self.script["view"].execute(self.scene, self.cast, self.props, self.script, "level_advance_view")
 
 
 

--- a/project/game/view_transition_action.py
+++ b/project/game/view_transition_action.py
@@ -5,6 +5,7 @@ from game.riddlemaster_view import RiddlemasterView
 from game.victory_view import VictoryView
 from game.game_over_view import GameOverView
 from game.instruction_view import InstructionView
+from game.level_advance_view import LevelAdvanceView
 
 class ViewTransitionAction(Action):
     """A code template for a thing done in a game. The responsibility of
@@ -38,6 +39,8 @@ class ViewTransitionAction(Action):
             self._victory_view(cast, props, script)
         elif view == 'instruction':
             self._instruction_view(scene, cast, props, script)
+        elif view == 'level_advance_view':
+            self._level_advance_view(scene, cast, props, script)
 
     def _start_view(self, scene, cast, props, script):
         """Handles the transition to the start screen.
@@ -121,4 +124,18 @@ class ViewTransitionAction(Action):
         """
         
         view = VictoryView(cast, props, script)
+        props["window"].show_view(view)
+
+    def _level_advance_view(self, scene, cast, props, script):
+        """Handles the transition to the level advance screen.
+
+        Args:
+            self (ViewTransitionAction): An instance of ViewTransitionAction.
+            scene (Scene): An instance of the Scene object.
+            cast (dict): The game actors {key: tag, value: list}.
+            props (dict): The game interface objects {key: tag, value: Arcade Object}
+            script (dict): The game Actions {key: tag, value: Action}
+        """
+        
+        view = LevelAdvanceView(scene, cast, props, script)
         props["window"].show_view(view)


### PR DESCRIPTION
The changes in this push enable map_2 but are not complete. The riddlemaster view needs some changes to the logic in the on_click_open as I changed from the victory view to the new level advance view. The logic does not include the victory after the second level completion.  There are no riddles for the second level so it throws an index out of range for the riddlemaster on the second level. 